### PR TITLE
Adjust mobile white section transparency

### DIFF
--- a/style.css
+++ b/style.css
@@ -416,6 +416,10 @@ button.form-btn{
 }
 
 @media (max-width: 1024px){
+  html,
+  body{
+    background-color: transparent;
+  }
   #main-block-text{
     position: absolute;
     top: 30px;
@@ -431,8 +435,19 @@ button.form-btn{
     text-align: center;
   }
   #main-left-block{
+    position: relative;
+    z-index: 0;
+    background: none;
+    background-color: transparent !important;
+  }
+  #main-left-block::before{
+    content: "";
+    position: fixed;
+    inset: 0;
     background: url(img/main.jpg) -40px 10px / 108% no-repeat;
     background-attachment: fixed;
+    z-index: -1;
+    pointer-events: none;
   }
   .about-text{ padding: 5%; }
   #main-photo{ display: none; }
@@ -524,9 +539,6 @@ h1.main strong {
 }
 
 @media (max-width: 768px){
-  body{
-    background: url(img/main.jpg) center / cover no-repeat fixed;
-  }
   .order-lesson{
     width: 52px;
     height: 52px;

--- a/style.css
+++ b/style.css
@@ -524,6 +524,9 @@ h1.main strong {
 }
 
 @media (max-width: 768px){
+  body{
+    background: url(img/main.jpg) center / cover no-repeat fixed;
+  }
   .order-lesson{
     width: 52px;
     height: 52px;
@@ -538,7 +541,7 @@ h1.main strong {
   section.about,
   .result,
   section.form{
-    background-color: rgba(255,255,255,0.6);
+    background-color: rgba(255,255,255,0.45);
   }
   section.form {
 
@@ -549,7 +552,7 @@ h1.main strong {
 
 @media (max-width: 703px){
   section.about{
-    background-color: rgba(255,255,255,0.6);
+    background-color: rgba(255,255,255,0.45);
     min-height: 370px;
     padding: 30px;
   }

--- a/style.css
+++ b/style.css
@@ -432,6 +432,7 @@ button.form-btn{
   }
   #main-left-block{
     background: url(img/main.jpg) -40px 10px / 108% no-repeat;
+    background-attachment: fixed;
   }
   .about-text{ padding: 5%; }
   #main-photo{ display: none; }
@@ -534,16 +535,21 @@ h1.main strong {
     justify-content: center;
   }
   .order-lesson__text{ display: none; }
+  section.about,
+  .result,
+  section.form{
+    background-color: rgba(255,255,255,0.6);
+  }
   section.form {
- 
+
       padding-top: 60px;
-   
+
   }
 }
 
 @media (max-width: 703px){
   section.about{
-    background-color: #fff;
+    background-color: rgba(255,255,255,0.6);
     min-height: 370px;
     padding: 30px;
   }


### PR DESCRIPTION
## Summary
- add a mobile breakpoint rule to render the white section backgrounds semi-transparent so the hero background remains visible while scrolling
- ensure the tighter mobile breakpoint keeps the about section at the same transparency level

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7894703c8832aadadff985c2eb269