### PR TITLE
Prevent browser caching of stylesheet

### DIFF
--- a/index.php
+++ b/index.php
@@ -12,6 +12,8 @@ $rememberCookieName = 'remember_auth';
 $rememberDuration = 30 * 24 * 60 * 60; // 30 days
 $secretKey = 'pRjFf3SxKZq8T0vL2nMhY1wB5cD9eG4u';
 $css = "style";
+$cssFile = __DIR__ . "/{$css}.css";
+$cssVersion = file_exists($cssFile) ? (string) filemtime($cssFile) : (string) time();
 
 $landingPageHtml = <<<HTML
 <!DOCTYPE html>
@@ -26,7 +28,7 @@ $landingPageHtml = <<<HTML
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
   
-  <link href="{$css}.css" rel="stylesheet">
+  <link href="{$css}.css?v={$cssVersion}" rel="stylesheet">
 </head>
 <body class="font-sans text-stone-800 antialiased">
   


### PR DESCRIPTION
## Summary
- add cache-busting version parameter to the stylesheet link in index.php to prevent caching issues

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e796c0f1cc832abcacd9f976b23bd6