### PR TITLE
Fix hero background attachment on tablet layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -44,6 +44,12 @@ html.js-ready [data-scroll]{
   will-change: opacity, transform;
 }
 
+/* keep fixed backgrounds working on sections that need parallax */
+html.js-ready #main-left-block[data-scroll]{
+  transform: none !important;
+  will-change: opacity;
+}
+
 html.js-ready [data-scroll].is-visible{
   opacity: 1;
   transform: translateY(0);


### PR DESCRIPTION
## Summary
- prevent the scroll-reveal transform from applying to the hero section so its background stays fixed
- limit the hero section's will-change hint to opacity to avoid breaking the parallax effect

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e79fd9a688832aac58e03e4ca2628a