### PR TITLE
Enhance contact form validation feedback

### DIFF
--- a/index.php
+++ b/index.php
@@ -414,51 +414,38 @@ $landingPageHtml = <<<HTML
 
       <form id="contact-form" class="space-y-5 reveal-child-zoom" data-scroll-child novalidate>
         <input type="hidden" name="contact_form" value="1" />
-
-        <div class="form-field">
-          <input
-            type="text"
-            name="name"
-            placeholder="Ваше ім'я"
-            autocomplete="name"
-            class="w-full sm:w-[80%] lg:w-[60%] mx-auto h-[52px] px-3 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#7a555b] text-[16px]"
-            required
-          />
-          <p class="form-error" data-error-for="name" aria-live="polite"></p>
-        </div>
-
-        <div class="form-field">
-          <input
-            type="text"
-            name="contact"
-            placeholder="Ваш Viber або Telegram"
-            autocomplete="tel"
-            class="w-full sm:w-[80%] lg:w-[60%] mx-auto h-[52px] px-3 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#7a555b] text-[16px]"
-            required
-          />
-          <p class="form-error" data-error-for="contact" aria-live="polite"></p>
-        </div>
-
-        <div class="form-field">
-          <textarea
-            name="message"
-            placeholder="Ваше повідомлення (необов'язково)"
-            class="w-full sm:w-[80%] lg:w-[60%] mx-auto h-[108px] px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#7a555b] text-[14px]"
-          ></textarea>
-          <p class="form-error" data-error-for="message" aria-live="polite"></p>
-        </div>
-
+        <input
+          type="text"
+          name="name"
+          placeholder="Ваше ім'я"
+          autocomplete="name"
+          class="w-full sm:w-[80%] lg:w-[60%] mx-auto h-[52px] px-3 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#7a555b] text-[16px]"
+          required
+        />
+        <p class="form-error" data-error-for="name" aria-live="polite"></p>
+        <input
+          type="text"
+          name="contact"
+          placeholder="Ваш Viber або Telegram"
+          autocomplete="tel"
+          class="w-full sm:w-[80%] lg:w-[60%] mx-auto h-[52px] px-3 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#7a555b] text-[16px]"
+          required
+        />
+        <p class="form-error" data-error-for="contact" aria-live="polite"></p>
+        <textarea
+          name="message"
+          placeholder="Ваше повідомлення (необов'язково)"
+          class="w-full sm:w-[80%] lg:w-[60%] mx-auto h-[108px] px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#7a555b] text-[14px]"
+        ></textarea>
+        <p class="form-error" data-error-for="message" aria-live="polite"></p>
         <button
           type="submit"
           class="w-full sm:w-[80%] lg:w-[60%] mx-auto h-[59px] bg-[#7a555b] text-white text-[18px] lg:text-[20px] font-medium rounded-lg shadow-md hover:bg-[#6b4950] transition"
         >
           Надіслати заявку
         </button>
-
         <div id="contact-status" class="contact-status" role="status" aria-live="polite"></div>
       </form>
-
-      <div id="contact-success" class="contact-success" role="status" aria-live="polite" hidden></div>
   </div>
 </section>
 

--- a/index.php
+++ b/index.php
@@ -414,35 +414,51 @@ $landingPageHtml = <<<HTML
 
       <form id="contact-form" class="space-y-5 reveal-child-zoom" data-scroll-child novalidate>
         <input type="hidden" name="contact_form" value="1" />
-        <input
-          type="text"
-          name="name"
-          placeholder="Ваше ім'я"
-          autocomplete="name"
-          class="w-full sm:w-[80%] lg:w-[60%] mx-auto h-[52px] px-3 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#7a555b] text-[16px]"
-          required
-        />
-        <input
-          type="text"
-          name="contact"
-          placeholder="Ваш Viber або Telegram"
-          autocomplete="tel"
-          class="w-full sm:w-[80%] lg:w-[60%] mx-auto h-[52px] px-3 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#7a555b] text-[16px]"
-          required
-        />
-        <textarea
-          name="message"
-          placeholder="Ваше повідомлення (необов'язково)"
-          class="w-full sm:w-[80%] lg:w-[60%] mx-auto h-[108px] px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#7a555b] text-[14px]"
-        ></textarea>
+
+        <div class="form-field">
+          <input
+            type="text"
+            name="name"
+            placeholder="Ваше ім'я"
+            autocomplete="name"
+            class="w-full sm:w-[80%] lg:w-[60%] mx-auto h-[52px] px-3 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#7a555b] text-[16px]"
+            required
+          />
+          <p class="form-error" data-error-for="name" aria-live="polite"></p>
+        </div>
+
+        <div class="form-field">
+          <input
+            type="text"
+            name="contact"
+            placeholder="Ваш Viber або Telegram"
+            autocomplete="tel"
+            class="w-full sm:w-[80%] lg:w-[60%] mx-auto h-[52px] px-3 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#7a555b] text-[16px]"
+            required
+          />
+          <p class="form-error" data-error-for="contact" aria-live="polite"></p>
+        </div>
+
+        <div class="form-field">
+          <textarea
+            name="message"
+            placeholder="Ваше повідомлення (необов'язково)"
+            class="w-full sm:w-[80%] lg:w-[60%] mx-auto h-[108px] px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#7a555b] text-[14px]"
+          ></textarea>
+          <p class="form-error" data-error-for="message" aria-live="polite"></p>
+        </div>
+
         <button
           type="submit"
           class="w-full sm:w-[80%] lg:w-[60%] mx-auto h-[59px] bg-[#7a555b] text-white text-[18px] lg:text-[20px] font-medium rounded-lg shadow-md hover:bg-[#6b4950] transition"
         >
           Надіслати заявку
         </button>
+
         <div id="contact-status" class="contact-status" role="status" aria-live="polite"></div>
       </form>
+
+      <div id="contact-success" class="contact-success" role="status" aria-live="polite" hidden></div>
   </div>
 </section>
 

--- a/script.js
+++ b/script.js
@@ -162,7 +162,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (contactForm) {
     const status = document.getElementById('contact-status');
-    const successBox = document.getElementById('contact-success');
     const submitButton = contactForm.querySelector('button[type="submit"]');
     const defaultButtonText = submitButton ? submitButton.textContent : '';
     const fieldNames = ['name', 'contact', 'message'];
@@ -199,11 +198,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const clearFieldErrors = () => {
       fieldNames.forEach((name) => {
-        const field = fields[name];
         const errorNode = errorNodes[name];
 
-        if (field) {
-          field.classList.remove('has-error');
+        if (fields[name]) {
+          fields[name].removeAttribute('aria-invalid');
         }
 
         if (errorNode) {
@@ -217,8 +215,6 @@ document.addEventListener('DOMContentLoaded', () => {
       const errorNode = errorNodes[name];
 
       if (field) {
-        field.classList.toggle('has-error', Boolean(message));
-
         if (message) {
           field.setAttribute('aria-invalid', 'true');
         } else {
@@ -243,11 +239,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
       clearFieldErrors();
       showStatus('', '');
-
-      if (successBox) {
-        successBox.hidden = true;
-        successBox.textContent = '';
-      }
 
       const nameValue = fields.name ? fields.name.value.trim() : '';
       const contactValue = fields.contact ? fields.contact.value.trim() : '';
@@ -323,16 +314,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         contactForm.reset();
         clearFieldErrors();
-        contactForm.classList.add('contact-form--hidden');
-
-        const successMessage = payload.message || 'Дякуємо! Повідомлення успішно відправлено.';
-
-        if (successBox) {
-          successBox.textContent = successMessage;
-          successBox.hidden = false;
-        } else {
-          showStatus(successMessage, 'contact-status--success');
-        }
+        showStatus(payload.message || 'Дякуємо! Повідомлення успішно відправлено.', 'contact-status--success');
       } catch (error) {
         console.error('Contact form submission failed', error);
         showStatus('Не вдалося відправити повідомлення. Перевірте підключення до інтернету.', 'contact-status--error');

--- a/script.js
+++ b/script.js
@@ -162,11 +162,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (contactForm) {
     const status = document.getElementById('contact-status');
+    const successBox = document.getElementById('contact-success');
     const submitButton = contactForm.querySelector('button[type="submit"]');
     const defaultButtonText = submitButton ? submitButton.textContent : '';
-    const nameInput = contactForm.querySelector('input[name="name"]');
-    const contactInput = contactForm.querySelector('input[name="contact"]');
-    const messageInput = contactForm.querySelector('textarea[name="message"]');
+    const fieldNames = ['name', 'contact', 'message'];
+    const fields = fieldNames.reduce((acc, name) => {
+      acc[name] = contactForm.querySelector(`[name="${name}"]`);
+      return acc;
+    }, {});
+    const errorNodes = fieldNames.reduce((acc, name) => {
+      acc[name] = contactForm.querySelector(`[data-error-for="${name}"]`);
+      return acc;
+    }, {});
 
     const showStatus = (text, type) => {
       if (!status) {
@@ -174,38 +181,97 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       status.classList.remove('contact-status--error', 'contact-status--success');
+
+      if (!text) {
+        status.textContent = '';
+        status.style.display = 'none';
+        return;
+      }
+
+      status.style.display = '';
+
       if (type) {
         status.classList.add(type);
       }
+
       status.textContent = text;
     };
+
+    const clearFieldErrors = () => {
+      fieldNames.forEach((name) => {
+        const field = fields[name];
+        const errorNode = errorNodes[name];
+
+        if (field) {
+          field.classList.remove('has-error');
+        }
+
+        if (errorNode) {
+          errorNode.textContent = '';
+        }
+      });
+    };
+
+    const setFieldError = (name, message) => {
+      const field = fields[name];
+      const errorNode = errorNodes[name];
+
+      if (field) {
+        field.classList.toggle('has-error', Boolean(message));
+
+        if (message) {
+          field.setAttribute('aria-invalid', 'true');
+        } else {
+          field.removeAttribute('aria-invalid');
+        }
+      }
+
+      if (errorNode) {
+        errorNode.textContent = message || '';
+      }
+    };
+
+    clearFieldErrors();
+    showStatus('', '');
 
     contactForm.addEventListener('submit', async (event) => {
       event.preventDefault();
 
-      if (!submitButton || !nameInput || !contactInput || !messageInput) {
+      if (!submitButton) {
         return;
       }
 
-      const nameValue = nameInput.value.trim();
-      const contactValue = contactInput.value.trim();
-      const messageValue = messageInput.value.trim();
+      clearFieldErrors();
+      showStatus('', '');
 
-      if (nameValue.length < 2) {
-        showStatus("Будь ласка, вкажіть ім'я (мінімум 2 символи).", 'contact-status--error');
-        nameInput.focus();
-        return;
+      if (successBox) {
+        successBox.hidden = true;
+        successBox.textContent = '';
       }
 
-      if (contactValue.length < 5) {
-        showStatus('Будь ласка, залиште ваш контакт для зворотного звʼязку.', 'contact-status--error');
-        contactInput.focus();
-        return;
+      const nameValue = fields.name ? fields.name.value.trim() : '';
+      const contactValue = fields.contact ? fields.contact.value.trim() : '';
+      const messageValue = fields.message ? fields.message.value.trim() : '';
+      let firstInvalidField = null;
+
+      if (fields.name && nameValue.length < 2) {
+        setFieldError('name', "Будь ласка, вкажіть ім'я (мінімум 2 символи).");
+        firstInvalidField = firstInvalidField || fields.name;
       }
 
-      if (messageValue.length > 1500) {
-        showStatus('Повідомлення занадто довге. Максимум 1500 символів.', 'contact-status--error');
-        messageInput.focus();
+      if (fields.contact && contactValue.length < 5) {
+        setFieldError('contact', 'Будь ласка, залиште ваш контакт для зворотного звʼязку.');
+        firstInvalidField = firstInvalidField || fields.contact;
+      }
+
+      if (fields.message && messageValue.length > 1500) {
+        setFieldError('message', 'Повідомлення занадто довге. Максимум 1500 символів.');
+        firstInvalidField = firstInvalidField || fields.message;
+      }
+
+      if (firstInvalidField) {
+        showStatus('Перевірте правильність заповнення форми.', 'contact-status--error');
+        firstInvalidField.focus();
         return;
       }
 
@@ -228,24 +294,51 @@ document.addEventListener('DOMContentLoaded', () => {
           body: formData,
         });
 
-        const payload = await response.json();
+        let payload = null;
 
-        if (!response.ok || !payload.success) {
+        try {
+          payload = await response.json();
+        } catch (parseError) {
+          console.error('Failed to parse response', parseError);
+        }
+
+        if (!response.ok || !payload || !payload.success) {
+          if (payload && payload.errors) {
+            const errorKeys = Object.keys(payload.errors);
+            let focused = false;
+
+            errorKeys.forEach((key) => {
+              setFieldError(key, payload.errors[key]);
+              if (!focused && fields[key]) {
+                fields[key].focus();
+                focused = true;
+              }
+            });
+          }
+
           const errorMessage = payload && payload.message ? payload.message : 'Сталася помилка під час відправлення.';
           showStatus(errorMessage, 'contact-status--error');
           return;
         }
 
         contactForm.reset();
-        showStatus(payload.message || 'Дякуємо! Повідомлення успішно відправлено.', 'contact-status--success');
+        clearFieldErrors();
+        contactForm.classList.add('contact-form--hidden');
+
+        const successMessage = payload.message || 'Дякуємо! Повідомлення успішно відправлено.';
+
+        if (successBox) {
+          successBox.textContent = successMessage;
+          successBox.hidden = false;
+        } else {
+          showStatus(successMessage, 'contact-status--success');
+        }
       } catch (error) {
         console.error('Contact form submission failed', error);
         showStatus('Не вдалося відправити повідомлення. Перевірте підключення до інтернету.', 'contact-status--error');
       } finally {
-        if (submitButton) {
-          submitButton.disabled = false;
-          submitButton.textContent = defaultButtonText;
-        }
+        submitButton.disabled = false;
+        submitButton.textContent = defaultButtonText;
       }
     });
   }

--- a/style.css
+++ b/style.css
@@ -464,6 +464,29 @@ section.form{
   margin-bottom: 20px;
 }
 
+.form-field{
+  position: relative;
+  max-width: min(600px, 90%);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.form-error{
+  min-height: 1.2em;
+  margin-top: 4px;
+  font-size: 14px;
+  line-height: 1.4;
+  color: #b91c1c;
+  text-align: left;
+  font-weight: 500;
+}
+
+.form input.has-error,
+.form textarea.has-error{
+  border-color: #b91c1c;
+  box-shadow: 0 0 0 1px rgba(185, 28, 28, 0.1);
+}
+
 .contact-status{
   min-height: 24px;
   margin: 10px auto 0;
@@ -478,6 +501,24 @@ section.form{
 
 .contact-status--error{ color: #b91c1c; }
 .contact-status--success{ color: #166534; }
+
+.contact-success{
+  margin: 24px auto 0;
+  max-width: min(600px, 90%);
+  padding: 20px;
+  border-radius: var(--radius);
+  background: #ecfdf5;
+  color: #166534;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: var(--shadow-sm);
+}
+
+.contact-form--hidden{
+  display: none;
+}
 
 /* глобальна кнопка (залишаю як у вас, щоб не ламати інші місця) */
 button.form-btn{

--- a/style.css
+++ b/style.css
@@ -464,27 +464,15 @@ section.form{
   margin-bottom: 20px;
 }
 
-.form-field{
-  position: relative;
-  max-width: min(600px, 90%);
-  margin-left: auto;
-  margin-right: auto;
-}
-
 .form-error{
-  min-height: 1.2em;
-  margin-top: 4px;
-  font-size: 14px;
-  line-height: 1.4;
+  min-height: 24px;
+  max-width: min(600px, 90%);
+  margin: 6px auto 0;
+  font-size: 16px;
+  line-height: 1.5;
   color: #b91c1c;
-  text-align: left;
+  text-align: center;
   font-weight: 500;
-}
-
-.form input.has-error,
-.form textarea.has-error{
-  border-color: #b91c1c;
-  box-shadow: 0 0 0 1px rgba(185, 28, 28, 0.1);
 }
 
 .contact-status{
@@ -501,24 +489,6 @@ section.form{
 
 .contact-status--error{ color: #b91c1c; }
 .contact-status--success{ color: #166534; }
-
-.contact-success{
-  margin: 24px auto 0;
-  max-width: min(600px, 90%);
-  padding: 20px;
-  border-radius: var(--radius);
-  background: #ecfdf5;
-  color: #166534;
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 600;
-  text-align: center;
-  box-shadow: var(--shadow-sm);
-}
-
-.contact-form--hidden{
-  display: none;
-}
 
 /* глобальна кнопка (залишаю як у вас, щоб не ламати інші місця) */
 button.form-btn{


### PR DESCRIPTION
## Summary
- add per-field error placeholders in the contact form and a dedicated success message container
- style validation errors and success notification states for the contact form
- enhance client-side handling to map validation errors to inputs and hide the form after a successful send

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68ea75d64570832a8d50151a9159067f