### PR TITLE
Hide contact form after successful submission

### DIFF
--- a/index.php
+++ b/index.php
@@ -453,6 +453,13 @@ $landingPageHtml = <<<HTML
         </button>
        
       </form>
+      <div
+        id="contact-status"
+        class="contact-status"
+        role="status"
+        aria-live="polite"
+        style="display: none;"
+      ></div>
   </div>
 </section>
 

--- a/index.php
+++ b/index.php
@@ -35,6 +35,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['contact_form'])) {
     };
 
     $errors = [];
+    $spamWindowSeconds = 5 * 60;
+    $now = time();
+    $lastSubmission = isset($_SESSION['contact_last_submit']) ? (int) $_SESSION['contact_last_submit'] : 0;
 
     if ($name === '' || $length($name) < 2) {
         $errors['name'] = "Будь ласка, вкажіть ім'я (мінімум 2 символи).";
@@ -58,6 +61,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['contact_form'])) {
         exit;
     }
 
+    if ($lastSubmission !== 0 && ($now - $lastSubmission) < $spamWindowSeconds) {
+        $retryAfter = $spamWindowSeconds - ($now - $lastSubmission);
+        http_response_code(429);
+        echo json_encode([
+            'success' => false,
+            'message' => 'Ви вже надсилали заявку нещодавно. Будь ласка, спробуйте ще раз через 5 хвилин.',
+            'retry_after' => $retryAfter,
+        ], JSON_UNESCAPED_UNICODE);
+        exit;
+    }
+
     $name = $sanitize($name);
     $contact = $sanitize($contact);
     $message = $sanitize($message);
@@ -74,6 +88,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['contact_form'])) {
     $mailSent = true;//mail($contactRecipient, $encodedSubject, $emailBody, implode("\r\n", $headers));
 
     if ($mailSent) {
+        $_SESSION['contact_last_submit'] = $now;
         echo json_encode([
             'success' => true,
             'message' => 'Дякуємо! Я звʼяжуся з вами найближчим часом.',

--- a/index.php
+++ b/index.php
@@ -54,7 +54,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['contact_form'])) {
         echo json_encode([
             'success' => false,
             'errors' => $errors,
-            'message' => 'Перевірте правильність заповнення форми.',
         ], JSON_UNESCAPED_UNICODE);
         exit;
     }

--- a/script.js
+++ b/script.js
@@ -158,6 +158,84 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  const heroSection = document.getElementById('main-left-block');
+  const heroMediaQuery = window.matchMedia('(max-width: 1024px)');
+
+  if (heroSection) {
+    let rafId = 0;
+    let scrollListenerAttached = false;
+
+    const applyOffset = () => {
+      rafId = 0;
+
+      if (!heroMediaQuery.matches) {
+        return;
+      }
+
+      const rect = heroSection.getBoundingClientRect();
+      const offset = rect.top * -1;
+      heroSection.style.setProperty('--hero-bg-offset', `${offset}px`);
+    };
+
+    const requestOffset = () => {
+      if (!heroMediaQuery.matches) {
+        return;
+      }
+
+      if (rafId !== 0) {
+        return;
+      }
+
+      rafId = window.requestAnimationFrame(applyOffset);
+    };
+
+    const detachScroll = () => {
+      if (!scrollListenerAttached) {
+        return;
+      }
+
+      window.removeEventListener('scroll', requestOffset);
+      scrollListenerAttached = false;
+    };
+
+    const attachScroll = () => {
+      if (scrollListenerAttached) {
+        return;
+      }
+
+      window.addEventListener('scroll', requestOffset, { passive: true });
+      scrollListenerAttached = true;
+    };
+
+    const enableHeroParallax = () => {
+      if (heroMediaQuery.matches) {
+        heroSection.classList.add('hero-fixed-background');
+        attachScroll();
+        applyOffset();
+      } else {
+        heroSection.classList.remove('hero-fixed-background');
+        detachScroll();
+
+        if (rafId !== 0) {
+          window.cancelAnimationFrame(rafId);
+          rafId = 0;
+        }
+
+        heroSection.style.removeProperty('--hero-bg-offset');
+      }
+    };
+
+    enableHeroParallax();
+
+    if (typeof heroMediaQuery.addEventListener === 'function') {
+      heroMediaQuery.addEventListener('change', enableHeroParallax);
+    } else if (typeof heroMediaQuery.addListener === 'function') {
+      heroMediaQuery.addListener(enableHeroParallax);
+    }
+
+    window.addEventListener('resize', requestOffset);
+  }
+
   const contactForm = document.getElementById('contact-form');
 
   if (contactForm) {

--- a/script.js
+++ b/script.js
@@ -261,7 +261,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       if (firstInvalidField) {
-        showStatus('Перевірте правильність заповнення форми.', 'contact-status--error');
+        showStatus('', '');
         firstInvalidField.focus();
         return;
       }
@@ -307,8 +307,14 @@ document.addEventListener('DOMContentLoaded', () => {
             });
           }
 
-          const errorMessage = payload && payload.message ? payload.message : 'Сталася помилка під час відправлення.';
-          showStatus(errorMessage, 'contact-status--error');
+          const hasMessage = payload && Object.prototype.hasOwnProperty.call(payload, 'message');
+          const errorMessage = hasMessage ? payload.message : 'Сталася помилка під час відправлення.';
+
+          if (errorMessage) {
+            showStatus(errorMessage, 'contact-status--error');
+          } else {
+            showStatus('', '');
+          }
           return;
         }
 

--- a/script.js
+++ b/script.js
@@ -314,7 +314,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
         contactForm.reset();
         clearFieldErrors();
-        showStatus(payload.message || 'Дякуємо! Повідомлення успішно відправлено.', 'contact-status--success');
+        contactForm.classList.add('contact-form--hidden');
+
+        const successMessage = payload.message || 'Дякуємо! Повідомлення успішно відправлено.';
+        showStatus(successMessage, 'contact-status--success');
+
+        if (status) {
+          status.setAttribute('tabindex', '-1');
+          status.focus();
+          status.addEventListener('blur', () => {
+            status.removeAttribute('tabindex');
+          }, { once: true });
+        }
       } catch (error) {
         console.error('Contact form submission failed', error);
         showStatus('Не вдалося відправити повідомлення. Перевірте підключення до інтернету.', 'contact-status--error');

--- a/script.js
+++ b/script.js
@@ -242,6 +242,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const status = document.getElementById('contact-status');
     const submitButton = contactForm.querySelector('button[type="submit"]');
     const defaultButtonText = submitButton ? submitButton.textContent : '';
+    const formHideDelay = 360;
+    let hideFormTimer = 0;
     const fieldNames = ['name', 'contact', 'message'];
     const fields = fieldNames.reduce((acc, name) => {
       acc[name] = contactForm.querySelector(`[name="${name}"]`);
@@ -257,11 +259,13 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
 
-      status.classList.remove('contact-status--error', 'contact-status--success');
+      status.classList.remove('contact-status--error', 'contact-status--success', 'contact-status--pending', 'contact-status--visible');
 
       if (!text) {
         status.textContent = '';
         status.style.display = 'none';
+        status.setAttribute('aria-hidden', 'true');
+        status.removeAttribute('tabindex');
         return;
       }
 
@@ -271,7 +275,22 @@ document.addEventListener('DOMContentLoaded', () => {
         status.classList.add(type);
       }
 
+      status.classList.add('contact-status--visible');
+      status.setAttribute('aria-hidden', 'false');
       status.textContent = text;
+    };
+
+    const hideFormWithAnimation = () => {
+      if (contactForm.classList.contains('contact-form--hidden')) {
+        return;
+      }
+
+      window.clearTimeout(hideFormTimer);
+      contactForm.classList.add('contact-form--sent');
+      hideFormTimer = window.setTimeout(() => {
+        contactForm.classList.add('contact-form--hidden');
+        contactForm.classList.remove('contact-form--sent');
+      }, formHideDelay);
     };
 
     const clearFieldErrors = () => {
@@ -344,7 +363,8 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
 
-      showStatus('Надсилаємо повідомлення…', '');
+      showStatus('Надсилаємо повідомлення…', 'contact-status--pending');
+      contactForm.classList.add('contact-form--submitting');
       submitButton.disabled = true;
       submitButton.textContent = 'Відправлення…';
 
@@ -398,7 +418,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
         contactForm.reset();
         clearFieldErrors();
-        contactForm.classList.add('contact-form--hidden');
 
         const successMessage = payload.message || 'Дякуємо! Повідомлення успішно відправлено.';
         showStatus(successMessage, 'contact-status--success');
@@ -410,12 +429,18 @@ document.addEventListener('DOMContentLoaded', () => {
             status.removeAttribute('tabindex');
           }, { once: true });
         }
+
+        contactForm.classList.remove('contact-form--submitting');
+        hideFormWithAnimation();
       } catch (error) {
         console.error('Contact form submission failed', error);
         showStatus('Не вдалося відправити повідомлення. Перевірте підключення до інтернету.', 'contact-status--error');
       } finally {
         submitButton.disabled = false;
         submitButton.textContent = defaultButtonText;
+        if (!contactForm.classList.contains('contact-form--hidden')) {
+          contactForm.classList.remove('contact-form--submitting');
+        }
       }
     });
   }

--- a/style.css
+++ b/style.css
@@ -597,6 +597,7 @@ h1.main strong {
     width: 220px; height: auto;
   }
 }
+
 @media (max-width: 930px){
   #try-first-leson{
     width: auto; height: auto;
@@ -660,6 +661,10 @@ h1.main strong {
 }
 
 @media (max-width: 768px){
+  #main-left-block{
+    background-attachment: scroll;
+    background-position: center top;
+  }
   .order-lesson{
     width: 52px;
     height: 52px;

--- a/style.css
+++ b/style.css
@@ -559,9 +559,17 @@ button.form-btn{
     text-align: center;
   }
   #main-left-block{
-    background: url(img/main.jpg) -40px 0px / 108% no-repeat;
-    background-attachment: fixed;
+    --hero-bg-offset: 0px;
+    --hero-bg-base-y: 0px;
+    background-image: url(img/main.jpg);
+    background-repeat: no-repeat;
+    background-size: 108%;
+    background-position-x: -40px;
+    background-position-y: calc(var(--hero-bg-base-y) + var(--hero-bg-offset));
   }/*
+  #main-left-block.hero-fixed-background{
+    will-change: background-position;
+  }
   body {
     background-color: transparent !important;
     background: url(img/main.jpg) -40px 10px / 108% no-repeat;
@@ -662,8 +670,8 @@ h1.main strong {
 
 @media (max-width: 768px){
   #main-left-block{
-    background-attachment: scroll;
-    background-position: center top;
+    --hero-bg-base-y: 0px;
+    background-position-x: center;
   }
   .order-lesson{
     width: 52px;

--- a/style.css
+++ b/style.css
@@ -464,6 +464,58 @@ section.form{
   margin-bottom: 20px;
 }
 
+#contact-form{
+  position: relative;
+  transition: transform .35s ease, opacity .35s ease;
+  will-change: transform, opacity;
+}
+
+#contact-form.contact-form--submitting{
+  pointer-events: none;
+  animation: contactFormPulse 1.1s ease-in-out infinite alternate;
+}
+
+#contact-form.contact-form--submitting::after{
+  content: "";
+  position: absolute;
+  inset: -8px;
+  border-radius: calc(var(--radius-lg) + 12px);
+  background: linear-gradient(135deg, rgba(255,255,255,0.85), rgba(255,255,255,0.55));
+  box-shadow: 0 25px 55px -35px rgba(122,85,91,0.65);
+  opacity: .95;
+  pointer-events: none;
+}
+
+#contact-form.contact-form--submitting::before{
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 42px;
+  height: 42px;
+  margin: -21px;
+  border-radius: 50%;
+  border: 3px solid rgba(122,85,91,0.22);
+  border-top-color: rgba(122,85,91,0.8);
+  animation: contactFormSpinner .75s linear infinite;
+  z-index: 1;
+}
+
+#contact-form.contact-form--sent{
+  opacity: 0;
+  transform: translateY(-14px) scale(.98);
+}
+
+@keyframes contactFormPulse{
+  from{ transform: scale(1); }
+  to{ transform: scale(.995); }
+}
+
+@keyframes contactFormSpinner{
+  from{ transform: rotate(0deg); }
+  to{ transform: rotate(360deg); }
+}
+
 .form-error{
   min-height: 24px;
   max-width: min(600px, 90%);
@@ -489,6 +541,93 @@ section.form{
 
 .contact-status--error{ color: #b91c1c; }
 .contact-status--success{ color: #166534; }
+
+#contact-status{
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 18px 22px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(122,85,91,0.15);
+  background: linear-gradient(135deg, rgba(255,255,255,0.95), rgba(255,255,255,0.72));
+  box-shadow: 0 25px 40px -32px rgba(122,85,91,0.65);
+  font-size: clamp(16px, 3.2vw, 18px);
+  line-height: 1.65;
+  color: #5b4146;
+  opacity: 0;
+  transform: translateY(-12px);
+  transition: opacity .35s ease, transform .35s ease, box-shadow .35s ease;
+}
+
+#contact-status::before{
+  content: "";
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: rgba(122,85,91,0.12);
+  border: 1px solid rgba(122,85,91,0.18);
+  display: none;
+}
+
+#contact-status.contact-status--visible{
+  opacity: 1;
+  transform: translateY(0);
+}
+
+#contact-status.contact-status--pending::before{
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  content: "…";
+  font-size: 20px;
+  color: rgba(122,85,91,0.8);
+}
+
+#contact-status.contact-status--pending{
+  border-color: rgba(122,85,91,0.25);
+  background: linear-gradient(135deg, rgba(122,85,91,0.12), rgba(122,85,91,0.04));
+  color: #604549;
+}
+
+#contact-status.contact-status--success{
+  border-color: rgba(22,101,52,0.35);
+  background: linear-gradient(135deg, rgba(86,168,139,0.22), rgba(203,246,220,0.55));
+  color: #14532d;
+  box-shadow: 0 28px 48px -30px rgba(20,83,45,0.6);
+}
+
+#contact-status.contact-status--success::before{
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(22,101,52,0.14);
+  border-color: rgba(22,101,52,0.35);
+  color: #166534;
+  content: "✓";
+  font-size: 20px;
+  font-weight: 600;
+}
+
+#contact-status.contact-status--error{
+  border-color: rgba(185,28,28,0.35);
+  background: linear-gradient(135deg, rgba(248,113,113,0.16), rgba(254,226,226,0.48));
+  color: #991b1b;
+  box-shadow: 0 28px 48px -30px rgba(185,28,28,0.45);
+}
+
+#contact-status.contact-status--error::before{
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(185,28,28,0.12);
+  border-color: rgba(185,28,28,0.35);
+  color: #991b1b;
+  content: "!";
+  font-size: 20px;
+  font-weight: 700;
+}
 
 .contact-form--hidden{
   display: none !important;

--- a/style.css
+++ b/style.css
@@ -490,6 +490,10 @@ section.form{
 .contact-status--error{ color: #b91c1c; }
 .contact-status--success{ color: #166534; }
 
+.contact-form--hidden{
+  display: none !important;
+}
+
 /* глобальна кнопка (залишаю як у вас, щоб не ламати інші місця) */
 button.form-btn{
   cursor: pointer;


### PR DESCRIPTION
## Summary
- add a dedicated status container next to the contact form to display submission feedback
- hide the contact form after a successful submission and focus the success message
- introduce a reusable CSS helper for hiding the form once the submission succeeds

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68ea7dbad8f8832aa7c1deac636beff4