### PR TITLE
Add mobile slider for tutor benefits section

### DIFF
--- a/index.php
+++ b/index.php
@@ -383,24 +383,29 @@ $landingPageHtml = <<<HTML
             </p>
           </div>
         </div>
-        <ul class="section-list mt-8 grid gap-4 md:grid-cols-2" data-scroll-child>
-          <li class="flex items-start gap-3 rounded-3xl bg-[#f3f0ef] p-4">
-            <span aria-hidden="true" class="section-list__icon mt-1">★</span>
-            <span class="section-list__text">Аналізую ваші цілі та створюю персональну траєкторію навчання.</span>
-          </li>
-          <li class="flex items-start gap-3 rounded-3xl bg-[#eef6f3] p-4">
-            <span aria-hidden="true" class="section-list__icon mt-1">★</span>
-            <span class="section-list__text">Поєдную розмовну практику, граматику та лексику в кожному уроці.</span>
-          </li>
-          <li class="flex items-start gap-3 rounded-3xl bg-[#f5f8ff] p-4">
-            <span aria-hidden="true" class="section-list__icon mt-1">★</span>
-            <span class="section-list__text">Надаю інтерактивні матеріали й записи занять для повторення.</span>
-          </li>
-          <li class="flex items-start gap-3 rounded-3xl bg-[#fff6f8] p-4">
-            <span aria-hidden="true" class="section-list__icon mt-1">★</span>
-            <span class="section-list__text">Супроводжую вас до досягнення результату як особистий репетитор англійської мови.</span>
-          </li>
-        </ul>
+        <div class="section-list-slider slider-container mt-8" data-slider data-scroll-child>
+          <ul class="section-list slider-track grid gap-4 md:grid-cols-2">
+            <li class="flex items-start gap-3 rounded-3xl bg-[#f3f0ef] p-4">
+              <span aria-hidden="true" class="section-list__icon mt-1">★</span>
+              <span class="section-list__text">Аналізую ваші цілі та створюю персональну траєкторію навчання.</span>
+            </li>
+            <li class="flex items-start gap-3 rounded-3xl bg-[#eef6f3] p-4">
+              <span aria-hidden="true" class="section-list__icon mt-1">★</span>
+              <span class="section-list__text">Поєдную розмовну практику, граматику та лексику в кожному уроці.</span>
+            </li>
+            <li class="flex items-start gap-3 rounded-3xl bg-[#f5f8ff] p-4">
+              <span aria-hidden="true" class="section-list__icon mt-1">★</span>
+              <span class="section-list__text">Надаю інтерактивні матеріали й записи занять для повторення.</span>
+            </li>
+            <li class="flex items-start gap-3 rounded-3xl bg-[#fff6f8] p-4">
+              <span aria-hidden="true" class="section-list__icon mt-1">★</span>
+              <span class="section-list__text">Супроводжую вас до досягнення результату як особистий репетитор англійської мови.</span>
+            </li>
+          </ul>
+          <button class="slider-arrow left" type="button" aria-label="Попередній">&#10094;</button>
+          <button class="slider-arrow right" type="button" aria-label="Наступний">&#10095;</button>
+          <div class="slider-dots" role="tablist" aria-label="Перемикання ключових переваг"></div>
+        </div>
         <div class="mt-10 text-center" data-scroll-child>
           <a href="#signup" class="inline-flex items-center justify-center rounded-md  bg-[#7a555b] px-8 py-3 text-lg font-medium text-white shadow-md transition hover:bg-[#6b4950]">
             Записатися до репетитора
@@ -412,8 +417,8 @@ $landingPageHtml = <<<HTML
     <section id="services" class="features" data-scroll>
       <h2 class="title" data-scroll-child>Що чекає на вас на наших заняттях?</h2>
       <p class="text" data-scroll-child>Комплексний підхід до ваших цілей від досвідченого репетитора англійської мови.</p>
-      <div class="slider-container">
-      <div class="blocks">
+      <div class="slider-container" data-slider>
+      <div class="blocks slider-track">
         <div class="card reveal-child-zoom" data-scroll-child>
         
 <h3> <svg xmlns="http://www.w3.org/2000/svg" style="display:inline-block; margin-right: 14px" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 31 31" width="31" height="31" fill="none">
@@ -543,9 +548,9 @@ $landingPageHtml = <<<HTML
           <p>Можливість займатися індивідуально або в парі з другом.</p>
         </div>
       </div>
-      <button class="slider-arrow left" aria-label="Попередній">&#10094;</button>
-      <button class="slider-arrow right" aria-label="Наступний">&#10095;</button>
-      <div class="slider-dots"></div>
+      <button class="slider-arrow left" type="button" aria-label="Попередній">&#10094;</button>
+      <button class="slider-arrow right" type="button" aria-label="Наступний">&#10095;</button>
+      <div class="slider-dots" role="tablist" aria-label="Перемикання послуг"></div>
       </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -72,18 +72,40 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  const container = document.querySelector('.features .blocks');
-  const cards = container ? container.querySelectorAll('.card') : [];
-  const prevBtn = document.querySelector('.features .slider-arrow.left');
-  const nextBtn = document.querySelector('.features .slider-arrow.right');
-  const dotsWrapper = document.querySelector('.features .slider-dots');
+  const sliderContainers = document.querySelectorAll('[data-slider]');
 
-  if (container && cards.length > 0 && prevBtn && nextBtn && dotsWrapper) {
+  sliderContainers.forEach((slider) => {
+    const track = slider.querySelector('.slider-track');
+    if (!track) {
+      return;
+    }
+
+    const items = Array.from(track.children);
+    const prevBtn = slider.querySelector('.slider-arrow.left');
+    const nextBtn = slider.querySelector('.slider-arrow.right');
+    const dotsWrapper = slider.querySelector('.slider-dots');
+
+    if (!prevBtn || !nextBtn || !dotsWrapper || items.length === 0) {
+      return;
+    }
+
+    const intervalAttr = Number.parseInt(slider.getAttribute('data-slider-interval') ?? '', 10);
+    const interval = Number.isFinite(intervalAttr) && intervalAttr > 0 ? intervalAttr : 110000;
+
+    dotsWrapper.innerHTML = '';
+
+    if (items.length <= 1) {
+      prevBtn.style.display = 'none';
+      nextBtn.style.display = 'none';
+      dotsWrapper.style.display = 'none';
+      return;
+    }
+
     let current = 0;
-    let auto = window.setInterval(nextSlide, 110000);
+    let auto = window.setInterval(nextSlide, interval);
     let scrollTimeout;
 
-    cards.forEach((_, index) => {
+    items.forEach((_, index) => {
       const dot = document.createElement('button');
       if (index === 0) {
         dot.classList.add('active');
@@ -98,10 +120,17 @@ document.addEventListener('DOMContentLoaded', () => {
       dotsWrapper.appendChild(dot);
     });
 
-    function scrollToCurrent() {
-      container.scrollTo({
-        left: cards[current].offsetLeft,
-        behavior: 'smooth',
+    function scrollToCurrent(options = {}) {
+      const behavior = options.instant ? 'auto' : 'smooth';
+      const target = items[current];
+
+      if (!target) {
+        return;
+      }
+
+      track.scrollTo({
+        left: target.offsetLeft,
+        behavior,
       });
       updateDots();
     }
@@ -113,18 +142,18 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function nextSlide() {
-      current = (current + 1) % cards.length;
+      current = (current + 1) % items.length;
       scrollToCurrent();
     }
 
     function prevSlide() {
-      current = (current - 1 + cards.length) % cards.length;
+      current = (current - 1 + items.length) % items.length;
       scrollToCurrent();
     }
 
     function resetAuto() {
       window.clearInterval(auto);
-      auto = window.setInterval(nextSlide, 110000);
+      auto = window.setInterval(nextSlide, interval);
     }
 
     nextBtn.addEventListener('click', () => {
@@ -137,15 +166,15 @@ document.addEventListener('DOMContentLoaded', () => {
       resetAuto();
     });
 
-    container.addEventListener('scroll', () => {
+    track.addEventListener('scroll', () => {
       window.clearTimeout(scrollTimeout);
       scrollTimeout = window.setTimeout(() => {
-        const scrollLeft = container.scrollLeft;
+        const scrollLeft = track.scrollLeft;
         let closest = 0;
         let min = Number.POSITIVE_INFINITY;
 
-        cards.forEach((card, index) => {
-          const diff = Math.abs(card.offsetLeft - scrollLeft);
+        items.forEach((item, index) => {
+          const diff = Math.abs(item.offsetLeft - scrollLeft);
           if (diff < min) {
             min = diff;
             closest = index;
@@ -156,7 +185,9 @@ document.addEventListener('DOMContentLoaded', () => {
         updateDots();
       }, 100);
     });
-  }
+
+    scrollToCurrent({ instant: true });
+  });
 
   const heroSection = document.getElementById('main-left-block');
   const heroMediaQuery = window.matchMedia('(max-width: 1024px)');

--- a/style.css
+++ b/style.css
@@ -865,22 +865,22 @@ h1.main strong {
 
 /* мобільний слайдер для .features */
 @media (max-width: 888px){
-	
-	
-	
+
+
+
   .slider-container{ position: relative; }
-  .blocks{
-    display: flex;
+  .slider-container .slider-track{
+    display: flex !important;
     overflow-x: auto;
     scroll-snap-type: x mandatory;
     -webkit-overflow-scrolling: touch;
     scroll-behavior: smooth;
-    padding: 0 16px;
-    margin-left: 32px;
-            padding-bottom: 60px;
+    padding: 0 16px 60px;
+    margin: 0 0 0 32px;
+    gap: 16px;
   }
-  .blocks::-webkit-scrollbar{ display: none; }
-  .card{
+  .slider-container .slider-track::-webkit-scrollbar{ display: none; }
+  .slider-container .slider-track > *{
     flex: 0 0 100%;
     display: block;
     width: 100%;
@@ -912,6 +912,15 @@ h1.main strong {
     background: #d1d5db;
   }
   .slider-dots button.active{ background: var(--primary); }
+}
+
+@media (max-width: 888px){
+  .section-list-slider .slider-track{
+    list-style: none;
+    margin: 0;
+    margin-left: 0;
+    padding-left: 0;
+  }
 }
 
 @media (max-width: 768px){


### PR DESCRIPTION
## Summary
- wrap the key benefits list in a slider container so it behaves like the lessons slider on mobile
- generalize the slider JavaScript to support any data-slider block and reuse it for the existing lessons carousel
- adjust responsive styles so both slider tracks share the same mobile layout while keeping the list appearance

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68f401e845cc832ab5e1ce8e809f9b70