### PR TITLE
Fix horizontal scroll on mobile slider

### DIFF
--- a/style.css
+++ b/style.css
@@ -889,9 +889,10 @@ h1.main strong {
     scroll-snap-type: x mandatory;
     -webkit-overflow-scrolling: touch;
     scroll-behavior: smooth;
-    padding: 0 16px 60px;
-    margin: 0 0 0 32px;
+    padding: 0 32px 60px;
+    margin: 0;
     gap: 16px;
+    box-sizing: border-box;
   }
   .slider-container .slider-track::-webkit-scrollbar{ display: none; }
   .slider-container .slider-track > *{


### PR DESCRIPTION
## Summary
- prevent the mobile slider track from exceeding the viewport width by removing the extra margin
- add box sizing so the mobile slider padding does not introduce overflow

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f4cf604c90832a8f11c05e1b557bb4