### PR TITLE
Fix horizontal overflow caused by scroll animations on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -844,16 +844,32 @@ button.form-btn{
 footer div p{ margin-top: 6px; width: 250px; text-align: center; }
 }
 @media (max-width: 1024px){
-	.text-block {
-    
+  /* prevent horizontal reveal offsets from causing page overflow on tablets and below */
+  [data-scroll]{
+    --reveal-translate-x: 0px !important;
+  }
+
+  [data-scroll-child]{
+    --child-translate-x: 0px !important;
+  }
+
+  [data-scroll-child].reveal-child-left,
+  [data-scroll-child].reveal-child-right{
+    --child-translate-x: 0px !important;
+  }
+
+  .text-block{
     color: #41393aff;
   }
-  h1.main span {
+
+  h1.main span{
     color: #41393aff;
-}
-h1.main strong {
+  }
+
+  h1.main strong{
     color: #976f00;
-}
+  }
+
   footer{
     grid-template-columns: 1fr;          /* колона на планшет/мобілку */
     justify-items: center;
@@ -861,8 +877,10 @@ h1.main strong {
     padding: 24px 20px;                  /* менші бокові відступи */
     row-gap: 12px;
   }
+
   footer img{
-    width: 220px; height: auto;
+    width: 220px;
+    height: auto;
   }
 }
 
@@ -942,6 +960,7 @@ h1.main strong {
     --hero-bg-base-y: 0px;
     background-position-x: center;
   }
+
   .order-lesson{
     width: 52px;
     height: 52px;


### PR DESCRIPTION
## Summary
- clear horizontal translate offsets for scroll reveal animations on viewports up to 1024px to avoid mobile overflow
- ensure reveal-child left/right variants no longer push content sideways on smaller screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f50bd5d940832a8c48cc225c9cd8a1