### PR TITLE
Load auth settings from environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+AUTH_ENABLED=true
+AUTH_USERNAME=admin
+AUTH_PASSWORD=StrongPass123
+
 SMTP_HOST=smtp.dashatutor.com.ua
 SMTP_PORT=587
 SMTP_USERNAME=no-reply@dashatutor.com.ua

--- a/index.php
+++ b/index.php
@@ -89,10 +89,24 @@ $getEnvValue = static function (string $key, $default = null) {
     return $value;
 };
 
+$authUsername = (string) $getEnvValue('AUTH_USERNAME', 'admin');
+$authPassword = (string) $getEnvValue('AUTH_PASSWORD', 'StrongPass123');
+
 $credentials = [
-    'username' => 'admin',
-    'password' => 'StrongPass123',
+    'username' => $authUsername,
+    'password' => $authPassword,
 ];
+
+$authEnabledValue = $getEnvValue('AUTH_ENABLED', 'true');
+$authEnabled = filter_var(
+    is_bool($authEnabledValue) ? $authEnabledValue : (string) $authEnabledValue,
+    FILTER_VALIDATE_BOOLEAN,
+    FILTER_NULL_ON_FAILURE
+);
+
+if ($authEnabled === null) {
+    $authEnabled = true;
+}
 
 $rememberCookieName = 'remember_auth';
 $rememberDuration = 30 * 24 * 60 * 60; // 30 days
@@ -1086,59 +1100,65 @@ function validateRememberToken(string $token, string $expectedUsername, string $
 }
 
 $authenticated = $_SESSION['authenticated'] ?? false;
-
-if (!$authenticated && isset($_COOKIE[$rememberCookieName])) {
-    $token = $_COOKIE[$rememberCookieName];
-
-    if (validateRememberToken($token, $credentials['username'], $secretKey)) {
-        $_SESSION['authenticated'] = true;
-        $authenticated = true;
-    } else {
-        setcookie($rememberCookieName, '', [
-            'expires' => time() - 3600,
-            'path' => '/',
-        ]);
-    }
-}
-
 $error = null;
 
-if (!$authenticated && $_SERVER['REQUEST_METHOD'] === 'POST') {
-    $username = trim((string)($_POST['username'] ?? ''));
-    $password = (string)($_POST['password'] ?? '');
-    $remember = isset($_POST['remember']);
+if ($authEnabled) {
+    if (!$authenticated && isset($_COOKIE[$rememberCookieName])) {
+        $token = $_COOKIE[$rememberCookieName];
 
-    if (
-        hash_equals($credentials['username'], $username)
-        && hash_equals($credentials['password'], $password)
-    ) {
-        $_SESSION['authenticated'] = true;
-
-        if ($remember) {
-            $token = createRememberToken($credentials['username'], $secretKey);
-            $cookieOptions = [
-                'expires' => time() + $rememberDuration,
-                'path' => '/',
-                'secure' => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
-                'httponly' => true,
-                'samesite' => 'Lax',
-            ];
-            setcookie($rememberCookieName, $token, $cookieOptions);
+        if (validateRememberToken($token, $credentials['username'], $secretKey)) {
+            $_SESSION['authenticated'] = true;
+            $authenticated = true;
         } else {
             setcookie($rememberCookieName, '', [
                 'expires' => time() - 3600,
                 'path' => '/',
             ]);
         }
-
-        header('Location: ' . $_SERVER['PHP_SELF']);
-        exit;
     }
 
-    $error = 'Невірний логін або пароль.';
-}
+    if (!$authenticated && $_SERVER['REQUEST_METHOD'] === 'POST') {
+        $username = trim((string)($_POST['username'] ?? ''));
+        $password = (string)($_POST['password'] ?? '');
+        $remember = isset($_POST['remember']);
 
-$authenticated = $_SESSION['authenticated'] ?? false;
+        if (
+            hash_equals($credentials['username'], $username)
+            && hash_equals($credentials['password'], $password)
+        ) {
+            $_SESSION['authenticated'] = true;
+
+            if ($remember) {
+                $token = createRememberToken($credentials['username'], $secretKey);
+                $cookieOptions = [
+                    'expires' => time() + $rememberDuration,
+                    'path' => '/',
+                    'secure' => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
+                    'httponly' => true,
+                    'samesite' => 'Lax',
+                ];
+                setcookie($rememberCookieName, $token, $cookieOptions);
+            } else {
+                setcookie($rememberCookieName, '', [
+                    'expires' => time() - 3600,
+                    'path' => '/',
+                ]);
+            }
+
+            header('Location: ' . $_SERVER['PHP_SELF']);
+            exit;
+        }
+
+        $error = 'Невірний логін або пароль.';
+    }
+
+    $authenticated = $_SESSION['authenticated'] ?? false;
+} else {
+    $authenticated = true;
+    if (($_SESSION['authenticated'] ?? false) !== true) {
+        $_SESSION['authenticated'] = true;
+    }
+}
 
 if ($authenticated) {
     header('Content-Type: text/html; charset=UTF-8');


### PR DESCRIPTION
## Summary
- read authentication username, password, and enabled flag from environment variables
- allow authentication to be disabled via the AUTH_ENABLED environment flag
- document the new environment variables in the example env file

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68f7b767d6e4832a84a1c4cbabcdb518